### PR TITLE
Fix: missing exports condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,11 @@
 		"accessibility"
 	],
 	"main": "./index.js",
-	"svelte": "./index.js",
+	"exports": {
+		".": {
+			"svelte": "./index.js"
+		}
+	},
 	"types": "./index.d.ts",
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
This PR fix warning for:

```bash
[vite-plugin-svelte] WARNING: The following packages have a svelte field in their package.json but no exports condition for svelte.

@a-luna/svelte-simple-tables@0.0.29

Please see https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition for details.
```

